### PR TITLE
Set the callback on UIGodotWindow at creation

### DIFF
--- a/Sources/SwiftGodotKit/iOS-GodotWindow.swift
+++ b/Sources/SwiftGodotKit/iOS-GodotWindow.swift
@@ -8,20 +8,19 @@ import SwiftUI
 import SwiftGodot
 
 public struct GodotWindow: UIViewRepresentable {
-    @State var callback: ((SwiftGodot.Window)->())?
     @State var node: String?
     @SwiftUI.Environment(\.godotApp) var app: GodotApp?
     var view = UIGodotWindow()
 
     public init (callback: ((SwiftGodot.Window)->())?) {
-        self.callback = callback
+        view.callback = callback
     }
     
     public func makeUIView(context: Context) -> UIGodotWindow {
         app?.start()
         view.contentScaleFactor = UIScreen.main.scale
         view.isMultipleTouchEnabled = true
-        view.callback = callback
+        
         view.node = node
         view.app = app
         return view


### PR DESCRIPTION
The callback was being reset to nil by the time it was set on the `UIGodotWindow` in `makeUIView` so the Godot content was never being displayed.