### PR TITLE
Allow SwiftGodotKit to replace the Godot NSApplicationDelegate

### DIFF
--- a/Sources/SwiftGodotKit/GodotApp.swift
+++ b/Sources/SwiftGodotKit/GodotApp.swift
@@ -16,6 +16,8 @@ public class GodotApp: ObservableObject {
     var pendingStart = Set<TTGodotAppView>()
     var pendingLayout = Set<TTGodotAppView>()
     var pendingWindow = Set<TTGodotWindow>()
+    
+    internal let appDelegate: GodotAppDelegate
 
     #if os(iOS)
     var touches: [UITouch?] = []
@@ -37,14 +39,15 @@ public class GodotApp: ObservableObject {
         godotPackPath: String? = nil,
         renderingDriver: String = "metal",
         renderingMethod: String = "mobile",
-        extraArgs: [String] = []
+        extraArgs: [String] = [],
+        appDelegate: GodotAppDelegate? = nil
     ) {
         let dir = godotPackPath ?? Bundle.main.resourcePath ?? "."
         path = "\(dir)/\(packFile)"
         self.renderingDriver = renderingDriver
         self.renderingMethod = renderingMethod
         self.extraArgs = extraArgs
-
+        self.appDelegate = appDelegate ?? GodotAppDelegate()
     }
 
     public func startPending() {
@@ -75,6 +78,7 @@ public class GodotApp: ObservableObject {
         if instance != nil {
             return true
         }
+        
         #if os(iOS)
         touches = [UITouch?](repeating: nil, count: maxTouchCount)
         #endif

--- a/Sources/SwiftGodotKit/GodotAppDelegate.swift
+++ b/Sources/SwiftGodotKit/GodotAppDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  GodotAppDelegate.swift
+//
+//
+
+#if os(macOS)
+
+import Foundation
+import AppKit
+
+import SwiftGodot
+
+open class GodotAppDelegate: NSObject, NSApplicationDelegate {
+    public func applicationDidBecomeActive(_ aNotification: Notification) {
+        Engine.getMainLoop()?.notification(what: Int32(MainLoop.notificationApplicationFocusIn))
+    }
+    
+    public func applicationDidResignActive(_ aNotification: Notification) {
+        Engine.getMainLoop()?.notification(what: Int32(MainLoop.notificationApplicationFocusOut))
+    }
+}
+
+#endif

--- a/Sources/SwiftGodotKit/macOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/macOS-GodotAppView.swift
@@ -3,6 +3,7 @@
 //
 //
 
+import OSLog
 import SwiftUI
 import SwiftGodot
 #if os(macOS)
@@ -13,6 +14,11 @@ public struct GodotAppView: NSViewRepresentable {
     public init () { }
     
     public func makeNSView(context: Context) -> NSGodotAppView {
+        guard let app else {
+            Logger.App.error("No GodotApp instance")
+            return view
+        }
+        
         view.app = app
         return view
     }

--- a/Sources/SwiftGodotKit/macOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/macOS-GodotAppView.swift
@@ -106,6 +106,10 @@ public class NSGodotAppView: NSView {
                 let link = displayLink(target: self, selector: #selector(iterate))
                 link.add(to: .current, forMode: RunLoop.Mode.default)
                 self.link = link
+                
+                if let delegate = app?.appDelegate {
+                    NSApplication.shared.delegate = delegate
+                }
             }
         } else if let app {
             app.queueStart(self)

--- a/Sources/SwiftGodotKit/macOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/macOS-GodotAppView.swift
@@ -123,7 +123,13 @@ public class NSGodotAppView: NSView {
     
     public override func viewDidMoveToSuperview() {
         commonInit()
-        startGodotInstance()
+    }
+    
+    public override func viewDidMoveToWindow() {
+        // It seems doing this in viewDidMoveToSuperview is too early to start the Godot app.
+        if window != nil {
+            app?.start()
+        }
     }
     
     @objc


### PR DESCRIPTION
The official godot Application delegate on macOS expects the display server to be macOS and crashes when delegate events happen. This replaces the delegate with one that handles events Godot requires manually.

It also allows custom delegates to be set, while maintaining the event handling that Godot expects

The delegate is set *after* the application starts so it will miss some events like (applicationDidFinishLaunching).