### PR TITLE
Replace the Godot NSApplicationDelegate

### DIFF
--- a/Sources/SwiftGodotKit/GodotApp.swift
+++ b/Sources/SwiftGodotKit/GodotApp.swift
@@ -16,6 +16,10 @@ public class GodotApp: ObservableObject {
     var pendingStart = Set<TTGodotAppView>()
     var pendingLayout = Set<TTGodotAppView>()
     var pendingWindow = Set<TTGodotWindow>()
+    
+    #if os(macOS)
+    internal let appDelegate: GodotAppDelegate
+    #endif
 
     #if os(iOS)
     var touches: [UITouch?] = []
@@ -44,7 +48,10 @@ public class GodotApp: ObservableObject {
         self.renderingDriver = renderingDriver
         self.renderingMethod = renderingMethod
         self.extraArgs = extraArgs
-
+        
+        #if os(macOS)
+        self.appDelegate = GodotAppDelegate()
+        #endif
     }
 
     public func startPending() {
@@ -75,6 +82,7 @@ public class GodotApp: ObservableObject {
         if instance != nil {
             return true
         }
+        
         #if os(iOS)
         touches = [UITouch?](repeating: nil, count: maxTouchCount)
         #endif
@@ -87,6 +95,11 @@ public class GodotApp: ObservableObject {
         args.append(contentsOf: extraArgs)
         
         instance = GodotInstance.create(args: args)
+        
+#if os(macOS)
+        NSApplication.shared.delegate = appDelegate
+#endif
+
         startPending()
         
         return instance != nil

--- a/Sources/SwiftGodotKit/GodotAppDelegate.swift
+++ b/Sources/SwiftGodotKit/GodotAppDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  GodotAppDelegate.swift
+//
+//
+
+#if os(macOS)
+
+import Foundation
+import AppKit
+
+import SwiftGodot
+
+open class GodotAppDelegate: NSObject, NSApplicationDelegate {
+    public func applicationDidBecomeActive(_ aNotification: Notification) {
+        Engine.getMainLoop()?.notification(what: Int32(MainLoop.notificationApplicationFocusIn))
+    }
+    
+    public func applicationDidResignActive(_ aNotification: Notification) {
+        Engine.getMainLoop()?.notification(what: Int32(MainLoop.notificationApplicationFocusOut))
+    }
+}
+
+#endif

--- a/Sources/SwiftGodotKit/macOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/macOS-GodotAppView.swift
@@ -3,6 +3,7 @@
 //
 //
 
+import OSLog
 import SwiftUI
 import SwiftGodot
 #if os(macOS)
@@ -13,6 +14,11 @@ public struct GodotAppView: NSViewRepresentable {
     public init () { }
     
     public func makeNSView(context: Context) -> NSGodotAppView {
+        guard let app else {
+            Logger.App.error("No GodotApp instance")
+            return view
+        }
+        
         view.app = app
         return view
     }

--- a/Sources/SwiftGodotKit/macOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/macOS-GodotAppView.swift
@@ -123,7 +123,13 @@ public class NSGodotAppView: NSView {
     
     public override func viewDidMoveToSuperview() {
         commonInit()
-        startGodotInstance()
+    }
+    
+    public override func viewDidMoveToWindow() {
+        // It seems doing this in viewDidMoveToSuperview is too early to start the Godot app.
+        if window != nil {
+            app?.start()
+        }
     }
     
     @objc


### PR DESCRIPTION
The official godot Application delegate on macOS expects the display server to be macOS and crashes when delegate events happen. This replaces the delegate with one that handles events Godot requires manually.

The delegate is set *after* the application starts so it will miss some events like (applicationDidFinishLaunching).