### PR TITLE
fix(macOS): call `super.removeFromSuperview()` in `NSGodotWindow`

### DIFF
--- a/Sources/SwiftGodotKit/macOS-GodotWindow.swift
+++ b/Sources/SwiftGodotKit/macOS-GodotWindow.swift
@@ -88,6 +88,7 @@ public class NSGodotWindow: GodotView {
     
     public override func removeFromSuperview() {
         subwindow?.getParent()?.removeChild(node: subwindow)
+        super.removeFromSuperview()
     }
 }
 #endif


### PR DESCRIPTION
### Issue

When `NSGodotWindow` calls `dealloc` it asserts that its `superview != nil`, which fails.
This can also be triggered by entering and leaving a `GodotWindow`.

### Root Cause

`NSGodotWindow.removeFromSuperview()` doesn't call `super.removeFromSuperview()`, which means AppKit's internal view hierarchy state is never updated. When the view is later deallocated, AppKit asserts because it still thinks the view has a superview.

### Solution

Add `super.removeFromSuperview()` call to ensure AppKit properly updates its internal state.

### Changes

**Before:**
```swift
public override func removeFromSuperview() {
    subwindow?.getParent()?.removeChild(node: subwindow)
}
```

**After:**
```swift
public override func removeFromSuperview() {
    subwindow?.getParent()?.removeChild(node: subwindow)
    super.removeFromSuperview()
}
```

### Testing

Tested by creating multiple `GodotWindow` instances in a `NavigationStack` and navigating between them repeatedly. Previously crashed on every navigation; now works without crashes.

### Impact

This is a critical fix for any macOS app using `GodotWindow` in a dynamic view hierarchy (`NavigationStack`, `TabView`, conditional rendering, etc.).