### PR TITLE
iOS: use native host path for non-embedded displays

### DIFF
--- a/Sources/SwiftGodotKit/iOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/iOS-GodotAppView.swift
@@ -6,9 +6,9 @@
 import OSLog
 import SwiftUI
 import SwiftGodot
-import UIKit
-
 #if os(iOS)
+import UIKit
+#endif
 public struct GodotAppView: UIViewRepresentable {
     @SwiftUI.Environment(\.godotApp) var app: GodotApp?
     var view = UIGodotAppView(frame: CGRect.zero)

--- a/Sources/SwiftGodotKit/iOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/iOS-GodotAppView.swift
@@ -6,6 +6,7 @@
 import OSLog
 import SwiftUI
 import SwiftGodot
+import UIKit
 
 #if os(iOS)
 public struct GodotAppView: UIViewRepresentable {
@@ -56,6 +57,7 @@ public struct GodotAppView: UIViewRepresentable {
         uiView.syncCallbackRegistration()
         uiView.startGodotInstance()
     }
+
 }
 
 typealias TTGodotAppView = UIGodotAppView
@@ -66,9 +68,13 @@ public class UIGodotAppView: UIView {
     private var displayLink : CADisplayLink? = nil
     
     private var embedded: DisplayServerEmbedded?
+    private weak var nativeIOSViewController: UIViewController?
     private var callbackToken: UUID?
     private weak var callbackApp: GodotApp?
     private var didEmitDisplayServerNotEmbeddedWarning = false
+    private var didEmitNativeIOSHostWarning = false
+    private var nativeIOSRenderingStarted = false
+    private var didRegisterNativeIOSViewController = false
     
     public var app: GodotApp?
     public var source: String?
@@ -83,46 +89,60 @@ public class UIGodotAppView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    
+
     private func commonInit() {
+        guard usesEmbeddedDisplayDriver else {
+            return
+        }
         let renderingLayer = CAMetalLayer()
         let size = max(UIScreen.main.bounds.size.width, UIScreen.main.bounds.size.height)
         renderingLayer.frame.size = CGSize(width: size, height: size)
-        renderingLayer.contentsScale = self.contentScaleFactor
+        renderingLayer.backgroundColor = UIColor.black.cgColor
         
         layer.addSublayer(renderingLayer)
+        backgroundColor = .black
         self.renderingLayer = renderingLayer
+        updateRenderingLayerGeometry()
     }
     
     deinit {
+        stopNativeIOSRendering()
+        nativeIOSViewController?.view.removeFromSuperview()
         renderingLayer?.removeFromSuperlayer()
         unregisterCallbacks()
     }
     
     public override var bounds: CGRect {
         didSet {
-            resizeWindow()
+            if usesEmbeddedDisplayDriver {
+                updateRenderingLayerGeometry()
+                resizeWindow()
+            } else {
+                layoutNativeIOSContainer()
+            }
         }
     }
     
     func resizeWindow() {
-        guard let embedded else {
-            logger.error("UIGodotApPView.resizeWindow invoked with no embedded window")
+        guard usesEmbeddedDisplayDriver else { return }
+        let size = pixelSize()
+
+        if let embedded {
+            embedded.resizeWindow(
+                size: size,
+                id: Int32(DisplayServer.mainWindowId)
+            )
             return
         }
-        
-        embedded.resizeWindow(
-            size: Vector2i(x: Int32(self.bounds.size.width * self.contentScaleFactor), y: Int32(self.bounds.size.height * self.contentScaleFactor)),
-            id: Int32(DisplayServer.mainWindowId)
-        )
+
+        logger.error("UIGodotAppView.resizeWindow invoked with no embedded window")
     }
 
     public override func layoutSubviews() {
-        if let renderingLayer {
-            renderingLayer.frame = self.bounds
-        }
-        if let instance = app?.instance {
-            if instance.isStarted() {
+        super.layoutSubviews()
+        if usesEmbeddedDisplayDriver {
+            updateRenderingLayerGeometry()
+            if let instance = app?.instance, instance.isStarted() {
                 if embedded == nil {
                     if let displayServer = DisplayServer.shared as? DisplayServerEmbedded {
                         embedded = displayServer
@@ -134,8 +154,10 @@ public class UIGodotAppView: UIView {
                     resizeWindow()
                 }
             }
+            return
         }
-        super.layoutSubviews()
+
+        layoutNativeIOSContainer()
     }
     
     func startGodotInstance() {
@@ -143,18 +165,29 @@ public class UIGodotAppView: UIView {
         guard let app else {
             return
         }
-        if renderingLayer == nil {
+
+        if renderingLayer == nil && usesEmbeddedDisplayDriver {
             commonInit()
         }
-        guard let renderingLayer else {
-            Logger.App.error("startGodotInstance: renderingLayer was nil")
-            return
+
+        if !usesEmbeddedDisplayDriver {
+            attachNativeIOSContainerIfNeeded()
         }
+
         if let instance = app.instance {
-            let rendererNativeSurface = RenderingNativeSurfaceApple.create(layer: UInt(bitPattern: Unmanaged.passUnretained(renderingLayer).toOpaque()))
-            DisplayServerEmbedded.setNativeSurface(rendererNativeSurface)
-            if !instance.isStarted() {
-                instance.start()
+            if usesEmbeddedDisplayDriver {
+                guard let renderingLayer else {
+                    Logger.App.error("startGodotInstance: renderingLayer was nil")
+                    return
+                }
+                let rendererNativeSurface = RenderingNativeSurfaceApple.create(
+                    layer: UInt(bitPattern: Unmanaged.passUnretained(renderingLayer).toOpaque())
+                )
+                DisplayServerEmbedded.setNativeSurface(rendererNativeSurface)
+            }
+
+            if usesEmbeddedDisplayDriver && !instance.isStarted() {
+                _ = instance.start()
                 app.startPending()
             }
             if displayLink == nil {
@@ -162,15 +195,19 @@ public class UIGodotAppView: UIView {
                 displayLink.add(to: .current, forMode: RunLoop.Mode.default)
                 self.displayLink = displayLink
             }
-            if embedded == nil {
+
+            if usesEmbeddedDisplayDriver, embedded == nil {
                 if let displayServer = DisplayServer.shared as? DisplayServerEmbedded {
                     embedded = displayServer
                 } else {
                     emitDisplayServerNotEmbeddedWarning(context: "startGodotInstance")
                 }
             }
-            if embedded != nil {
+
+            if usesEmbeddedDisplayDriver {
                 resizeWindow()
+            } else {
+                syncNativeIOSRenderingState()
             }
             app.pollBridgeAndReadiness()
         } else {
@@ -179,7 +216,7 @@ public class UIGodotAppView: UIView {
     }
 
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let app, let instance = app.instance, let renderingLayer else { return }
+        guard let app, app.instance != nil, let renderingLayer else { return }
         let contentsScale = renderingLayer.contentsScale
         
         var touchData: [[String : Any]] = []
@@ -197,29 +234,27 @@ public class UIGodotAppView: UIView {
             let tapCount = touch.tapCount
             touchData.append([ "touchId": touchId, "location": location, "tapCount": tapCount ])
         }
-        {
-            let windowId = Int32(DisplayServer.mainWindowId)
-            for touch in touchData {
-                guard let touchId = touch["touchId"] as? Int,
-                      let location = touch["location"] as? CGPoint,
-                      let tapCount = touch["tapCount"] as? Int,
-                      let displayServer = DisplayServer.shared as? DisplayServerEmbedded
-                else { continue }
-                
-                displayServer.touchPress (
-                    idx: Int32(touchId),
-                    x: Int32(location.x * contentsScale),
-                    y: Int32(location.y * contentsScale),
-                    pressed: true,
-                    doubleClick: tapCount > 1,
-                    window: windowId
-                )
-            }
-        }()
+        let windowId = Int32(DisplayServer.mainWindowId)
+        for touch in touchData {
+            guard let touchId = touch["touchId"] as? Int,
+                  let location = touch["location"] as? CGPoint,
+                  let tapCount = touch["tapCount"] as? Int,
+                  let displayServer = DisplayServer.shared as? DisplayServerEmbedded
+            else { continue }
+            
+            displayServer.touchPress (
+                idx: Int32(touchId),
+                x: Int32(location.x * contentsScale),
+                y: Int32(location.y * contentsScale),
+                pressed: true,
+                doubleClick: tapCount > 1,
+                window: windowId
+            )
+        }
     }
     
     public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let app, let renderingLayer, let instance = app.instance else { return }
+        guard let app, app.instance != nil, let renderingLayer else { return }
         let contentsScale = renderingLayer.contentsScale
         
         var touchData: [[String : Any]] = []
@@ -247,24 +282,22 @@ public class UIGodotAppView: UIView {
             touchData.append([ "touchId": touchId, "location": location, "prevLocation": prevLocation, "alt": alt, "azim": azim, "force": force, "maximumPossibleForce": maximumPossibleForce ])
         }
         
-        {
-            let windowId = Int32(DisplayServer.mainWindowId)
-            for touch in touchData {
-                guard let touchId = touch["touchId"] as? Int,
-                      let location = touch["location"] as? CGPoint,
-                      let prevLocation = touch["prevLocation"] as? CGPoint,
-                      let alt = touch["alt"] as? CGFloat,
-                      let azim = touch["azim"] as? CGVector,
-                      let force = touch["force"] as? CGFloat,
-                      let maximumPossibleForce = touch["maximumPossibleForce"] as? CGFloat,
-                      let displayServer = DisplayServer.shared as? DisplayServerEmbedded else { continue }
-                displayServer.touchDrag(idx: Int32(touchId), prevX: Int32(prevLocation.x  * contentsScale), prevY: Int32(prevLocation.y  * contentsScale), x: Int32(location.x * contentsScale), y: Int32(location.y * contentsScale), pressure: Double(force) / Double(maximumPossibleForce), tilt: Vector2(x: Float(azim.dx) * Float(cos(alt)), y: Float(azim.dy) * cos(Float(alt))), window: windowId)
-            }
-        }()
+        let windowId = Int32(DisplayServer.mainWindowId)
+        for touch in touchData {
+            guard let touchId = touch["touchId"] as? Int,
+                  let location = touch["location"] as? CGPoint,
+                  let prevLocation = touch["prevLocation"] as? CGPoint,
+                  let alt = touch["alt"] as? CGFloat,
+                  let azim = touch["azim"] as? CGVector,
+                  let force = touch["force"] as? CGFloat,
+                  let maximumPossibleForce = touch["maximumPossibleForce"] as? CGFloat,
+                  let displayServer = DisplayServer.shared as? DisplayServerEmbedded else { continue }
+            displayServer.touchDrag(idx: Int32(touchId), prevX: Int32(prevLocation.x  * contentsScale), prevY: Int32(prevLocation.y  * contentsScale), x: Int32(location.x * contentsScale), y: Int32(location.y * contentsScale), pressure: Double(force) / Double(maximumPossibleForce), tilt: Vector2(x: Float(azim.dx) * Float(cos(alt)), y: Float(azim.dy) * cos(Float(alt))), window: windowId)
+        }
     }
 
     public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let app, let renderingLayer, let instance = app.instance else { return }
+        guard let app, app.instance != nil, let renderingLayer else { return }
         let contentsScale = renderingLayer.contentsScale
         
         var touchData: [[String : Any]] = []
@@ -283,26 +316,24 @@ public class UIGodotAppView: UIView {
             touchData.append([ "touchId": touchId, "location": location ])
         }
         
-        {
-            let windowId = Int32(DisplayServer.mainWindowId)
-            for touch in touchData {
-                guard let touchId = touch["touchId"] as? Int,
-                      let location = touch["location"] as? CGPoint,
-                      let displayServer = DisplayServer.shared as? DisplayServerEmbedded else { continue }
-                displayServer.touchPress (
-                    idx: Int32(touchId),
-                    x: Int32(location.x * contentsScale),
-                    y: Int32(location.y * contentsScale),
-                    pressed: false,
-                    doubleClick: false,
-                    window: windowId
-                )
-            }
-        }()
+        let windowId = Int32(DisplayServer.mainWindowId)
+        for touch in touchData {
+            guard let touchId = touch["touchId"] as? Int,
+                  let location = touch["location"] as? CGPoint,
+                  let displayServer = DisplayServer.shared as? DisplayServerEmbedded else { continue }
+            displayServer.touchPress (
+                idx: Int32(touchId),
+                x: Int32(location.x * contentsScale),
+                y: Int32(location.y * contentsScale),
+                pressed: false,
+                doubleClick: false,
+                window: windowId
+            )
+        }
     }
     
     public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
-        guard let app, let instance = app.instance else { return }
+        guard let app, app.instance != nil else { return }
         var touchData: [[String : Any]] = []
         for touch in touches {
             let touchId = app.getTouchId(touch: touch)
@@ -313,20 +344,20 @@ public class UIGodotAppView: UIView {
             touchData.append([ "touchId": touchId ])
         }
         
-        {
-            let windowId = Int32(DisplayServer.mainWindowId)
-            for touch in touchData {
-                guard let touchId = touch["touchId"] as? Int,
-                      let displayServer = DisplayServer.shared as? DisplayServerEmbedded else { continue }
-                
-                displayServer.touchesCanceled(idx: Int32(touchId), window: windowId)
-            }
-        }()
+        let windowId = Int32(DisplayServer.mainWindowId)
+        for touch in touchData {
+            guard let touchId = touch["touchId"] as? Int,
+                  let displayServer = DisplayServer.shared as? DisplayServerEmbedded else { continue }
+            
+            displayServer.touchesCanceled(idx: Int32(touchId), window: windowId)
+        }
     }
     
     public override func removeFromSuperview() {
         displayLink?.invalidate()
         displayLink = nil
+        stopNativeIOSRendering()
+        nativeIOSViewController?.view.removeFromSuperview()
         unregisterCallbacks()
         super.removeFromSuperview()
     }
@@ -335,25 +366,173 @@ public class UIGodotAppView: UIView {
         if superview == nil {
             return
         }
-        if renderingLayer == nil {
+        if renderingLayer == nil && usesEmbeddedDisplayDriver {
             commonInit()
+        }
+        if usesEmbeddedDisplayDriver {
+            updateRenderingLayerGeometry()
+        } else {
+            attachNativeIOSContainerIfNeeded()
+            layoutNativeIOSContainer()
         }
         startGodotInstance()
     }
 
     @objc
     func iterate() {
-        if let app, (app.isPaused || !app.isDrawing) {
+        guard let app else { return }
+
+        if usesEmbeddedDisplayDriver {
+            if app.isPaused || !app.isDrawing {
+                return
+            }
+            if let instance = app.instance, instance.isStarted() {
+                _ = instance.iteration()
+                app.pollBridgeAndReadiness()
+            }
             return
         }
-        if let instance = app?.instance, instance.isStarted() {
-            instance.iteration()
-            app?.pollBridgeAndReadiness()
-        }
+
+        syncNativeIOSRenderingState()
+        app.pollBridgeAndReadiness()
     }
+
+
 }
 
 private extension UIGodotAppView {
+    var usesEmbeddedDisplayDriver: Bool {
+        app?.displayDriver == "embedded"
+    }
+
+    func updateRenderingLayerGeometry() {
+        guard let renderingLayer else { return }
+        renderingLayer.frame = bounds
+        let scale = max(window?.screen.scale ?? contentScaleFactor, CGFloat(1))
+        renderingLayer.contentsScale = scale
+        renderingLayer.drawableSize = CGSize(
+            width: max(CGFloat(1), bounds.size.width * scale),
+            height: max(CGFloat(1), bounds.size.height * scale)
+        )
+    }
+
+    func pixelSize() -> Vector2i {
+        if let renderingLayer {
+            return Vector2i(
+                x: Int32(max(CGFloat(1), renderingLayer.drawableSize.width).rounded()),
+                y: Int32(max(CGFloat(1), renderingLayer.drawableSize.height).rounded())
+            )
+        }
+        return Vector2i(
+            x: Int32(self.bounds.size.width * self.contentScaleFactor),
+            y: Int32(self.bounds.size.height * self.contentScaleFactor)
+        )
+    }
+
+    func attachNativeIOSContainerIfNeeded() {
+        guard !usesEmbeddedDisplayDriver else { return }
+        guard let controller = nativeIOSViewController ?? makeNativeIOSViewController() else { return }
+
+        if !didRegisterNativeIOSViewController {
+            registerNativeIOSViewController(controller)
+            didRegisterNativeIOSViewController = true
+        }
+
+        let controllerView = controller.view!
+        if controllerView.superview !== self {
+            insertSubview(controllerView, at: 0)
+        }
+
+        layoutNativeIOSContainer()
+    }
+
+    func layoutNativeIOSContainer() {
+        guard !usesEmbeddedDisplayDriver else { return }
+        guard let controllerView = nativeIOSViewController?.view else { return }
+        controllerView.frame = bounds
+        controllerView.setNeedsLayout()
+        controllerView.layoutIfNeeded()
+    }
+
+    func makeNativeIOSViewController() -> UIViewController? {
+        guard let viewControllerType = NSClassFromString("GDTViewController") as? NSObject.Type else {
+            emitNativeIOSHostWarning("GDTViewController runtime class is unavailable")
+            return nil
+        }
+
+        let object = viewControllerType.init()
+        guard let controller = object as? UIViewController else {
+            emitNativeIOSHostWarning("GDTViewController resolved, but did not bridge to UIViewController")
+            return nil
+        }
+        controller.loadViewIfNeeded()
+        nativeIOSViewController = controller
+        return controller
+    }
+
+    func registerNativeIOSViewController(_ controller: UIViewController) {
+        guard let serviceClass = NSClassFromString("GDTAppDelegateService") else {
+            emitNativeIOSHostWarning("GDTAppDelegateService runtime class is unavailable")
+            return
+        }
+
+        let selector = NSSelectorFromString("setViewController:")
+        let serviceObject: AnyObject = serviceClass
+        guard serviceObject.responds(to: selector) else {
+            emitNativeIOSHostWarning("GDTAppDelegateService.setViewController: is unavailable")
+            return
+        }
+
+        _ = serviceObject.perform(selector, with: controller)
+    }
+
+    func syncNativeIOSRenderingState() {
+        guard !usesEmbeddedDisplayDriver else { return }
+        attachNativeIOSContainerIfNeeded()
+
+        let hasDrawableBounds = bounds.width > 1 && bounds.height > 1
+        if !hasDrawableBounds {
+            stopNativeIOSRendering()
+            return
+        }
+
+        if let app, app.isPaused || !app.isDrawing {
+            stopNativeIOSRendering()
+        } else {
+            startNativeIOSRendering()
+        }
+    }
+
+    func startNativeIOSRendering() {
+        guard !nativeIOSRenderingStarted else { return }
+        guard let hostView = nativeIOSViewController?.view else { return }
+
+        let startSelector = NSSelectorFromString("startRendering")
+        let hostObject: AnyObject = hostView
+        guard hostObject.responds(to: startSelector) else {
+            emitNativeIOSHostWarning("GDTView.startRendering is unavailable")
+            return
+        }
+
+        _ = hostObject.perform(startSelector)
+        nativeIOSRenderingStarted = true
+    }
+
+    func stopNativeIOSRendering() {
+        guard nativeIOSRenderingStarted else { return }
+        guard let hostView = nativeIOSViewController?.view else {
+            nativeIOSRenderingStarted = false
+            return
+        }
+
+        let stopSelector = NSSelectorFromString("stopRendering")
+        let hostObject: AnyObject = hostView
+        if hostObject.responds(to: stopSelector) {
+            _ = hostObject.perform(stopSelector)
+        }
+        nativeIOSRenderingStarted = false
+    }
+
     func emitDisplayServerNotEmbeddedWarning(context: String) {
         guard !didEmitDisplayServerNotEmbeddedWarning else { return }
         didEmitDisplayServerNotEmbeddedWarning = true
@@ -367,6 +546,12 @@ private extension UIGodotAppView {
                 )
             )
         )
+    }
+
+    func emitNativeIOSHostWarning(_ detail: String) {
+        guard !didEmitNativeIOSHostWarning else { return }
+        didEmitNativeIOSHostWarning = true
+        Logger.App.error("\(detail, privacy: .public)")
     }
 
     func syncCallbackRegistration() {


### PR DESCRIPTION
## Summary

This fixes the iOS host path when `GodotApp` is launched with the native iOS display driver instead of the embedded display driver.

Before this change, `UIGodotAppView` always assumed an embedded-surface setup:

- it always created its own `CAMetalLayer`
- it always called `DisplayServerEmbedded.setNativeSurface(...)`
- it always resized the main window through `DisplayServerEmbedded`

That works for the embedded display-driver path, but it breaks when the app is actually running with the native iOS display driver.

In practice, that showed up as:

- a startup crash when `DisplayServerEmbedded.setNativeSurface(...)` tried to bind a method that does not exist on the native iOS display-server path
- or a blank render surface, because SwiftGodotKit was mounting the wrong kind of host for the display driver that Godot was actually using

This PR keeps the fix focused on that mismatch.

## Problem

On iOS, the current host implementation mixes together two different rendering models:

1. an embedded host model, where SwiftGodotKit provides the render surface and talks to `DisplayServerEmbedded`
2. a native iOS host model, where Godot uses its own iOS host/controller classes (`GDTViewController` / `GDTView`)

The existing implementation in `iOS-GodotAppView.swift` always takes the first path, even when `GodotApp.displayDriver` is `"iOS"`.

That mismatch is the core bug.

This is also why the conditional in this change exists.

The goal here is not to add broad “support every host model everywhere” branching throughout the file. The goal is simply to make the iOS host match the display driver that was selected at launch:

- if the app is using `embedded`, keep the existing embedded-surface path
- if the app is using `iOS`, stop calling embedded-only APIs and mount the native iOS host instead

## What This Changes

For the embedded display-driver path, the existing behavior stays in place:

- create/manage the `CAMetalLayer`
- call `DisplayServerEmbedded.setNativeSurface(...)`
- resize the Godot main window through `DisplayServerEmbedded`

For the native iOS display-driver path, `UIGodotAppView` now:

- skips embedded-only display-server setup
- creates a `GDTViewController` via the Objective-C runtime
- registers that controller with `GDTAppDelegateService`
- mounts the controller's view inside the SwiftUI-hosted `UIGodotAppView`
- keeps that native host view sized to the container bounds
- starts/stops native rendering based on the existing pause/draw state

In other words, the change is intentionally concentrated at the host boundary. The rest of the system can keep using `GodotApp` the same way it already does.

## Why This Is Structured As A Single Host Boundary Split

While debugging this in a real iPhone app, I tried a few broader iOS-side changes:

- extra UIKit sizing helpers
- alternate touch forwarding paths
- additional subwindow changes

Those experiments made the patch larger, but they were not the fundamental fix.

The actual issue was simpler: the iOS host was always going through the embedded display path, even when Godot was launched with the native iOS display driver.

So this PR intentionally keeps the conditional narrow and local:

- one path for `embedded`
- one path for native iOS hosting

That keeps the change easier to reason about, and it makes the conditional reflect a real runtime distinction instead of becoming a general “iOS special case” switch.

## Follow-up From Review

I also made one small follow-up adjustment after the initial PR was opened:

- `UIKit` is now imported only under `#if os(iOS)` in `iOS-GodotAppView.swift`

That keeps the file safe for macOS package parsing/builds while still allowing the iOS-specific host code to use UIKit normally.
