### PR TITLE
Guard engine start against run-loop re-entrancy

### DIFF
--- a/Sources/SwiftGodotKit/GodotApp.swift
+++ b/Sources/SwiftGodotKit/GodotApp.swift
@@ -88,6 +88,8 @@ public class GodotApp: ObservableObject {
     /// Engine boot pumps the run loop; these keep re-entrant callers from booting twice.
     @ObservationIgnored public private(set) var isCreatingInstance = false
     @ObservationIgnored internal var isStartingEngine = false
+    /// A failed Main::setup2 leaves no way to retry; never start this instance again.
+    @ObservationIgnored internal var engineStartFailed = false
     @ObservationIgnored public private(set) var isPaused = false
     @ObservationIgnored public private(set) var isDrawing = true
     @ObservationIgnored private var hostBridge: SwiftGodotHostBridge?

--- a/Sources/SwiftGodotKit/GodotApp.swift
+++ b/Sources/SwiftGodotKit/GodotApp.swift
@@ -85,6 +85,9 @@ public class GodotApp: ObservableObject {
     
     /// The Godot instance for this host, if it was successfully created
     @ObservationIgnored public var instance: GodotInstance?
+    /// Engine boot pumps the run loop; these keep re-entrant callers from booting twice.
+    @ObservationIgnored public private(set) var isCreatingInstance = false
+    @ObservationIgnored internal var isStartingEngine = false
     @ObservationIgnored public private(set) var isPaused = false
     @ObservationIgnored public private(set) var isDrawing = true
     @ObservationIgnored private var hostBridge: SwiftGodotHostBridge?
@@ -161,10 +164,12 @@ public class GodotApp: ObservableObject {
     public func startPending() {
         guard instance != nil else { return }
 
-        for view in pendingStart {
+        // Taken first: startGodotInstance can re-queue a view mid-drain.
+        let starting = pendingStart
+        pendingStart.removeAll()
+        for view in starting {
             view.startGodotInstance()
         }
-        pendingStart.removeAll()
 
         for view in pendingLayout {
 #if os(macOS)
@@ -186,6 +191,9 @@ public class GodotApp: ObservableObject {
             }
             return true
         }
+        if isCreatingInstance { return false }
+        isCreatingInstance = true
+        defer { isCreatingInstance = false }
 
         #if os(iOS)
         touches = [UITouch?](repeating: nil, count: maxTouchCount)

--- a/Sources/SwiftGodotKit/iOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/iOS-GodotAppView.swift
@@ -155,7 +155,13 @@ public class UIGodotAppView: UIView {
             let rendererNativeSurface = RenderingNativeSurfaceApple.create(layer: UInt(bitPattern: Unmanaged.passUnretained(renderingLayer).toOpaque()))
             DisplayServerAppleEmbeddedBridge.setNativeSurface(rendererNativeSurface)
             if !instance.isStarted() {
+                if app.isStartingEngine {
+                    app.queueStart(self)
+                    return
+                }
+                app.isStartingEngine = true
                 instance.start()
+                app.isStartingEngine = false
                 app.startPending()
             }
             if displayLink == nil {

--- a/Sources/SwiftGodotKit/iOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/iOS-GodotAppView.swift
@@ -155,13 +155,18 @@ public class UIGodotAppView: UIView {
             let rendererNativeSurface = RenderingNativeSurfaceApple.create(layer: UInt(bitPattern: Unmanaged.passUnretained(renderingLayer).toOpaque()))
             DisplayServerAppleEmbeddedBridge.setNativeSurface(rendererNativeSurface)
             if !instance.isStarted() {
+                if app.engineStartFailed { return }
                 if app.isStartingEngine {
                     app.queueStart(self)
                     return
                 }
                 app.isStartingEngine = true
-                instance.start()
+                let started = instance.start()
                 app.isStartingEngine = false
+                guard started else {
+                    app.engineStartFailed = true
+                    return
+                }
                 app.startPending()
             }
             if displayLink == nil {

--- a/Sources/SwiftGodotKit/macOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/macOS-GodotAppView.swift
@@ -140,10 +140,17 @@ public class NSGodotAppView: GodotView {
             let alreadyStarted = instance.isStarted()
             print("[SwiftGodotKit] startGodotInstance after instance.isStarted() -> \(alreadyStarted)")
             if !alreadyStarted {
+                if app.isStartingEngine {
+                    app.queueStart(self)
+                    return
+                }
+                app.isStartingEngine = true
                 let started = instance.start()
+                app.isStartingEngine = false
                 Logger.App.info("startGodotInstance: instance.start() -> \(started)")
                 print("[SwiftGodotKit] startGodotInstance instance.start() -> \(started)")
                 stderrLog("startGodotInstance instance.start() -> \(started)")
+                app.startPending()
             }
             if app.displayDriver == "embedded", embedded == nil {
                 if let displayServer = DisplayServer.shared as? DisplayServerEmbedded {

--- a/Sources/SwiftGodotKit/macOS-GodotAppView.swift
+++ b/Sources/SwiftGodotKit/macOS-GodotAppView.swift
@@ -140,6 +140,7 @@ public class NSGodotAppView: GodotView {
             let alreadyStarted = instance.isStarted()
             print("[SwiftGodotKit] startGodotInstance after instance.isStarted() -> \(alreadyStarted)")
             if !alreadyStarted {
+                if app.engineStartFailed { return }
                 if app.isStartingEngine {
                     app.queueStart(self)
                     return
@@ -150,6 +151,10 @@ public class NSGodotAppView: GodotView {
                 Logger.App.info("startGodotInstance: instance.start() -> \(started)")
                 print("[SwiftGodotKit] startGodotInstance instance.start() -> \(started)")
                 stderrLog("startGodotInstance instance.start() -> \(started)")
+                guard started else {
+                    app.engineStartFailed = true
+                    return
+                }
                 app.startPending()
             }
             if app.displayDriver == "embedded", embedded == nil {


### PR DESCRIPTION
`GodotInstance.create(args:)` and `instance.start()` both pump the main run loop while the engine boots. On macOS, if a `GodotAppView` is inside a window that is still being constructed — e.g. `NSWindow(contentViewController:)` called from `applicationDidFinishLaunching` — AppKit delivers further `viewDidMoveToWindow` calls during that pump. Each one calls `app?.start()` again, and since `instance` is still nil (the outer create hasn't returned), a **second GodotInstance is created and started in the same process**. Godot's per-process singletons already exist, so the second boot logs a wall of `Condition "singleton != nullptr" is true` and crashes in `Main::setup2`:

```
* thread #1, stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
  frame #0: libgodotkit RendererSceneCull::set_scene_render(RendererSceneRender*) + 20
  frame #1: libgodotkit Main::setup2(bool) + 7216
  frame #2: libgodotkit GodotInstance::start() + 44
  frame #4: SwiftGodot GodotInstance.start()
  frame #5: NSGodotAppView.startGodotInstance()
  frame #7: GodotApp.start()
  frame #8: NSGodotAppView.viewDidMoveToWindow()
  frame #10: AppKit -[NSView _setWindow:]        <- window still being built
  frame #16: AppKit -[NSWindow setContentView:]
  frame #26: applicationDidFinishLaunching
```

Whether it fires depends on when the view lands in a window: opening the Godot window later (from a button, an existing run loop turn) never hit it; opening it during app launch hit it every time.

The fix is two guards on `GodotApp`:

- `isCreatingInstance` around `GodotInstance.create` — a re-entrant `start()` backs off and returns false; its view queues via the existing `queueStart` path and is drained by the outer call's `startPending()`.
- `isStartingEngine` around `instance.start()` in `NSGodotAppView`/iOS `GodotAppView` — a re-entrant view queues itself and returns; the outer call drains the queue once the engine is up.

`startPending()` now takes the pending set before iterating, so a view re-queued mid-drain isn't silently dropped by the trailing `removeAll()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
